### PR TITLE
examples/energy-gateway-app: Commodity Metering: nullable timestamp on  clock error

### DIFF
--- a/examples/energy-gateway-app/commodity-metering/src/CommodityMeteringEventTriggers.cpp
+++ b/examples/energy-gateway-app/commodity-metering/src/CommodityMeteringEventTriggers.cpp
@@ -182,12 +182,16 @@ private:
         uint32_t matterEpoch = 0;
 
         CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(matterEpoch);
-        if (err != CHIP_NO_ERROR)
+        if (err == CHIP_NO_ERROR)
         {
-            ChipLogError(Support, "UpdAttrs() could not get time");
+            ChipLogDetail(Support, "UpdAttrs() got time: %" PRIu32, matterEpoch);
+            mMeteredQuantityTimestamp.SetNonNull(matterEpoch);
         }
-
-        mMeteredQuantityTimestamp.SetNonNull(matterEpoch);
+        else
+        {
+            ChipLogError(Support, "UpdAttrs() could not get time, setting Null");
+            mMeteredQuantityTimestamp.SetNull();
+        }
 
         if (mTariffUnit.IsNull() || (mTariffUnit.Value() == Globals::TariffUnitEnum::kKWh))
         {


### PR DESCRIPTION


Follow-up to project-chip/connectedhomeip#39724 review note (“Should this return?”) that became project-chip/connectedhomeip#40048 and was later rolled into the umbrella issue project-chip/connectedhomeip#40140.

Behavior change in UpdAttrs():
- On success of System::Clock::GetClock_MatterEpochS, set mMeteredQuantityTimestamp.SetNonNull(matterEpoch).
- On failure, log error and set mMeteredQuantityTimestamp.SetNull().

This matches the cluster XML (Nullable) and avoids leaving a stale/unspecified value when the Matter epoch isn’t available.

Refs: project-chip/connectedhomeip#40140
Fixes: project-chip/connectedhomeip#40048
Related-to: project-chip/connectedhomeip#39724

#### Summary

<!--
    This section will help the reviewer better understand the context of this change.
    Please provide a TLDR appropriate to the change's complexity on what was changed and why.
    If fixing an error, explain the root cause and the chosen solution's rationale, especially if not obvious.
    Include context like links to related documents/issues/test plans and highlight notable information or specific concerns.

    See guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#pr-summary-description
    See title formatting: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting

    Please replace this HTML comment with the actual PR summary.
-->

#### Related issues

<!--
    This section will help the reviewer easily navigate to the GitHub issues related to this PR change.
    Please mention all the related issues in this section.

    Tip: use the syntax of Fixes #.... to mark issues completed on PR merge or use #... to reference issues that are addressed.

    Examples:
        Fixes: #12345
        #12345
        N/A (not preferable)

    Please replace this HTML comment with the actual information about related issues.
-->

#### Testing

<!--
    This section will help the reviewer understand how this PR change was tested.
    As a general rule, a proposed PR change must not break the existing code and must be well-tested.
    Please include information about testing.

    See testing guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#testing

    Examples:
        added unit tests
        verified by YAML test: TC_ABC.yaml
        added Python test: TC_DEF.py
        manually tested (mention steps to reproduce)

    Please replace this HTML comment with the actual information about how the testing was done.
 -->

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
