### PR TITLE
examples/energy-gateway-app: Commodity Metering: use designated initalizers in sample data

### DIFF
--- a/examples/energy-gateway-app/commodity-metering/src/CommodityMeteringEventTriggers.cpp
+++ b/examples/energy-gateway-app/commodity-metering/src/CommodityMeteringEventTriggers.cpp
@@ -35,8 +35,14 @@ static constexpr uint32_t TariffComponents2[] = { 0x5002, 0x5003, 0x5004 };
 
 // Non-constexpr storage for the actual data
 static const Structs::MeteredQuantityStruct::Type Data[] = {
-    { DataModel::List(TariffComponents1, MATTER_ARRAY_SIZE(TariffComponents1)), 3500 },
-    { DataModel::List(TariffComponents2, MATTER_ARRAY_SIZE(TariffComponents2)), -2000 }
+    {
+        .tariffComponentIDs = DataModel::List(TariffComponents1, MATTER_ARRAY_SIZE(TariffComponents1)),
+        .quantity = 3500
+    },
+    {
+        .tariffComponentIDs = DataModel::List(TariffComponents2, MATTER_ARRAY_SIZE(TariffComponents2)),
+        .quantity = -2000
+    }
 };
 } // namespace Sample1
 
@@ -45,8 +51,14 @@ static constexpr uint32_t TariffComponents1[] = { 0x6001 };
 static constexpr uint32_t TariffComponents2[] = { 0x6002, 0x6003 };
 
 static const Structs::MeteredQuantityStruct::Type Data[] = {
-    { DataModel::List(TariffComponents1, MATTER_ARRAY_SIZE(TariffComponents1)), 4200 },
-    { DataModel::List(TariffComponents2, MATTER_ARRAY_SIZE(TariffComponents2)), -1500 }
+    {
+        .tariffComponentIDs = DataModel::List(TariffComponents1, MATTER_ARRAY_SIZE(TariffComponents1)),
+        .quantity = 4200
+    },
+    {
+        .tariffComponentIDs = DataModel::List(TariffComponents2, MATTER_ARRAY_SIZE(TariffComponents2)),
+        .quantity = -1500
+    }
 };
 } // namespace Sample2
 } // namespace MeteredQuantitySamples


### PR DESCRIPTION
Follow-up to readability feedback on PR project-chip/connectedhomeip#39724 (comment by @jamesharrow), which was tracked in project-chip/connectedhomeip#40050 and later consolidated under project-chip/connectedhomeip#40140.

Change:
- Replace positional aggregate initialization with designated initializers for Structs::MeteredQuantityStruct::Type (.tariffComponentIDs, .quantity).
- Keep MATTER_ARRAY_SIZE() usage.

No functional changes; readability only.

Refs: project-chip/connectedhomeip#40140
Related-to: project-chip/connectedhomeip#39724, project-chip/connectedhomeip#40050

#### Summary

#### Related issues

#### Testing

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
